### PR TITLE
fix: 防止重构消息绕过 GIF 图片预处理

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
 import asyncio
+from pathlib import Path
 from typing import Dict
 from astrbot.api.star import Context, Star
 from astrbot.api.event import filter, AstrMessageEvent
 from astrbot.api import AstrBotConfig, logger
+from astrbot.core.utils.astrbot_path import get_astrbot_temp_path
+from astrbot.core.utils.media_utils import MediaResolver, ensure_jpeg
 
 from .message_parser import MessageParser, IS_AIOCQHTTP
 from .forward_handler import ForwardHandler
@@ -467,6 +470,44 @@ class ContinuousMessagePlugin(Star):
         merged_text = self.merge_separator.join(buffer).strip()
         merged_text, all_images = await self.link_parser.enrich(merged_text, all_images)
         parsed_added_image_count = max(len(all_images) - original_image_count, 0)
+
+        # The plugin rebuilds the event after AstrBot's preprocess stage. Run
+        # image normalization again so raw GIFs from replies, forwards, or link
+        # parsing cannot bypass the core GIF-to-JPEG conversion.
+        normalized_images = []
+        for image_ref in all_images:
+            try:
+                local_path = await MediaResolver(
+                    image_ref,
+                    media_type="image",
+                    default_suffix=".bin",
+                ).to_path()
+                try:
+                    resolved_local_path = Path(local_path).resolve()
+                    resolved_local_path.relative_to(
+                        Path(get_astrbot_temp_path()).resolve()
+                    )
+                    event.track_temporary_local_file(str(resolved_local_path))
+                except (OSError, ValueError):
+                    pass
+
+                jpeg_path = await ensure_jpeg(local_path)
+                try:
+                    resolved_jpeg_path = Path(jpeg_path).resolve()
+                    resolved_jpeg_path.relative_to(
+                        Path(get_astrbot_temp_path()).resolve()
+                    )
+                    event.track_temporary_local_file(str(resolved_jpeg_path))
+                except (OSError, ValueError):
+                    pass
+
+                if jpeg_path not in normalized_images:
+                    normalized_images.append(jpeg_path)
+            except Exception as exc:
+                logger.warning(
+                    f"[消息防抖动] 图片标准化失败，已忽略该图片: {exc}"
+                )
+        all_images = normalized_images
         
         if not merged_text and not all_images:
             self._silence_event(event)

--- a/message_parser.py
+++ b/message_parser.py
@@ -523,6 +523,8 @@ class MessageParser:
                         image_urls.append(component.url)
                     elif hasattr(component, 'file') and component.file:
                         image_urls.append(component.file)
+                    elif hasattr(component, 'path') and component.path:
+                        image_urls.append(component.path)
         except Exception as exc:
             logger.error(f"[消息防抖动] 消息解析异常: {exc}")
 
@@ -535,7 +537,11 @@ class MessageParser:
             text = f"{text}\n{card_text}" if text else card_text
 
         raw_image_urls = self._extract_image_urls_from_raw_message(message_obj)
-        if raw_image_urls:
+        # AstrBot may have downloaded and normalized the image component during
+        # preprocessing (for example, converting GIF to JPEG). Preserve that
+        # provider-ready reference and only fall back to the raw platform URL
+        # when the component does not contain a usable image reference.
+        if raw_image_urls and not image_urls:
             image_urls = raw_image_urls
             has_image = True
 


### PR DESCRIPTION
## 问题背景

AstrBot 会在预处理阶段将 GIF 等图片统一转换为 JPEG，但本插件在防抖结算时会重新构造消息事件，并优先使用 QQ 原始消息中的图片 URL。这会覆盖已经预处理过的本地 JPEG 路径，使原始 image/gif 直接进入 LLM Provider。对于不支持 GIF 的 Gemini 兼容接口，请求会持续返回 mime type is not supported 错误。

## 修复内容

- 优先保留 AstrBot 已预处理的图片组件引用，并补充 path 属性支持。
- 仅在图片组件没有有效引用时，才回退读取平台原始图片 URL。
- 在重构事件前统一解析最终图片并调用 ensure_jpeg，覆盖普通图片、引用图片、合并转发图片和链接解析新增图片。
- 无法验证或转换的图片会被忽略，避免把不受支持的 MIME 类型传给 Provider。
- 跟踪转换过程中产生的临时文件，交由事件生命周期清理。

## 验证

- python -m py_compile main.py message_parser.py
- git diff --check